### PR TITLE
check whether connection attempt was successful in wifi_start

### DIFF
--- a/arduino/samd/libraries/CO2-Ampel/examples/CO2-Ampel/CO2-Ampel.ino
+++ b/arduino/samd/libraries/CO2-Ampel/examples/CO2-Ampel/CO2-Ampel.ino
@@ -1683,6 +1683,11 @@ unsigned int wifi_start(void)
     status_led(1000); //Status-LED
   }
 
+  if(!(WiFi.status() == WL_CONNECTED))
+  {
+    return 1;
+  }
+
   server.begin(); //starte Webserver
 
   return 0;


### PR DESCRIPTION
This will make the setup() code reopen the AP if you have entered a wrong WiFi password, e.g. 
Otherwise you are stuck with a device only accessible via serial, or via using special key combinations.